### PR TITLE
Use globalThis for $templates variable declaration

### DIFF
--- a/src/code-generator-dynamic-impl.ts
+++ b/src/code-generator-dynamic-impl.ts
@@ -109,7 +109,7 @@ export class DynamicCodeGenerator implements CodeGenerator, SourceBuilder {
 
 "use strict";
 
-var $templates = {
+globalThis.$templates = {
 `;
     for (const [name, template] of repo.templates) {
       contents += `  ${JSON.stringify(name)}: function(param, variable, shader_helper) {

--- a/test/testcases/build-basic/expected/dynamic/templates.js
+++ b/test/testcases/build-basic/expected/dynamic/templates.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-var $templates = {
+globalThis.$templates = {
   "shader/triangle.wgsl.template": function(param, variable, shader_helper) {
     var $emitAdditional = function (code) {
       shader_helper.appendAdditionalImplementation(code);

--- a/test/testcases/build-example-pad/expected/dynamic/templates.js
+++ b/test/testcases/build-example-pad/expected/dynamic/templates.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-var $templates = {
+globalThis.$templates = {
   "tensor/pad.wgsl.template": function(param, variable, shader_helper) {
     var $emitAdditional = function (code) {
       shader_helper.appendAdditionalImplementation(code);


### PR DESCRIPTION
Update the variable declaration for $templates to use globalThis, ensuring better global scope accessibility.